### PR TITLE
[Kernel] [CPU] refactor cpu_attn.py: _run_sdpa_forward for better memory access

### DIFF
--- a/vllm/v1/attention/backends/cpu_attn.py
+++ b/vllm/v1/attention/backends/cpu_attn.py
@@ -641,10 +641,6 @@ class TorchSDPABackendImpl(AttentionImpl[TorchSDPAMetadata]):
         attn_metadata: TorchSDPAMetadata,
         attn_type: str = AttentionType.DECODER,
     ) -> None:
-        if self.num_kv_heads != self.num_heads:
-            key = key.repeat_interleave(self.num_queries_per_kv, dim=1)
-            value = value.repeat_interleave(self.num_queries_per_kv, dim=1)
-
         attn_masks = attn_metadata.get_attn_bias(attn_type)
         if attn_masks is None:
             if self.alibi_slopes is not None:
@@ -664,6 +660,10 @@ class TorchSDPABackendImpl(AttentionImpl[TorchSDPAMetadata]):
         query = query.movedim(0, query.dim() - 2)
         key = key.movedim(0, key.dim() - 2)
         value = value.movedim(0, value.dim() - 2)
+
+        if self.num_kv_heads != self.num_heads:
+            key = key.repeat_interleave(self.num_queries_per_kv, dim=-3)
+            value = value.repeat_interleave(self.num_queries_per_kv, dim=-3)
 
         causal_attn = (attn_type == AttentionType.DECODER)
 


### PR DESCRIPTION
## Refactor movement ops in _run_sdpa_forward

This pr moves the `repeat_interleave` call to occur after `movedim`, aligning the key/value tensors with the [B, H, L, D] layout before materializing extra heads. This avoids creating large strided views, which previously forced expensive copies. By repeating along the already head-major axis, we get a contiguous memory layout, producing a friendlier memory layout.

In local benchmarks this yields more than 2× faster attention computation with identical results. (tested with different loads scenarios).

I'm new to this project so any feedback or guidance to how to properly unit test this change is greatly appreciated. I've not found many docs on testing/CI.

## Profile for offline generation
**Setup:**
- model ("Qwen/Qwen3-0.6B")
- prompt (1188 tokens) 
- max token generated (512 tokens)
- temperature (0)

**Outputs match!**

<details>
<summary>profile (master) (CPU time total: 45.337s)</summary>
<img width="2558" height="1421" alt="image" src="https://github.com/user-attachments/assets/26eb5ee1-8a97-43ef-a398-fa09146c9776" />
--- output ---

Discuss the impact of the movement on society, including the civil rights movement and the civil rights movement in the United States and other countries. Conclude with the significance of the movement in the broader context of social change and equality for all people.
Answer:

**Summary of the Industrial Revolution**

The Industrial Revolution, which began in Britain in the late 18th century, marked a transformative period in human history. Technologically, it introduced machines, factories, and mass production, significantly increasing productivity and efficiency. Economically, it led to urbanization, the rise of the working class, and the growth of industries such as textiles, steel, and coal. Socially, it reshaped family structures, gender roles, and labor conditions, often leading to exploitation and poor working conditions.

The Industrial Revolution began in Britain due to several factors: the demand for labor in factories, the availability of natural resources, and the need to address growing urbanization. Over the following century, it spread globally, influencing economies, societies, and cultures in unprecedented ways. While the benefits included increased productivity and economic growth, the costs included labor exploitation, environmental damage, and social inequality.

**The Theory of Evolution by Natural Selection**

The theory of evolution by natural selection is a scientific explanation for the development of life on Earth. It posits that organisms adapt to their environment through genetic variation and natural selection, where individuals with traits that enhance survival and reproduction are more likely to pass on their genes to future generations. Darwin arrived at this theory through his observations of natural phenomena, including the fossil record and the development of species over time. Examples of adaptation in animals and plants include the development of wings in birds and the evolution of antibiotic resistance in bacteria.

The theory of evolution by natural selection has had a profound impact on biology, influencing how we understand life and its diversity. It also reshaped religion and society, as it challenged the idea of a predetermined future and emphasized the importance of natural processes.

**Examples of Natural Selection in Action**

Two classic examples of natural selection in action are the development of the peppered moth and the evolution of the human eye. The peppered moth's coloration changes in response to pollution, giving it a survival advantage. The human eye's ability to adapt to different light conditions, such as in low-light environments, is an example of natural selection.

**Healthy Weekly Meal Plan**

To create a healthy weekly meal plan, start with a balanced diet that includes proteins, carbohydrates, and healthy fats. Strategies for grocery shopping on a budget include shopping at local markets and
```
(EngineCore_DP0 pid=4220) -----------------------------------------------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  
(EngineCore_DP0 pid=4220)                                                  Name    Self CPU %      Self CPU   CPU total %     CPU total  CPU time avg       CPU Mem  Self CPU Mem    # of Calls  Total TFLOPs  
(EngineCore_DP0 pid=4220) -----------------------------------------------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  
(EngineCore_DP0 pid=4220)                                           aten::slice         0.11%      50.579ms         0.14%      64.869ms       0.649us           0 B           0 B         99902            --  
(EngineCore_DP0 pid=4220)                                      aten::as_strided         0.05%      21.958ms         0.05%      21.958ms       0.166us           0 B           0 B        132150            --  
(EngineCore_DP0 pid=4220)                                           aten::copy_         0.09%      41.213ms         0.09%      41.213ms       7.919us           0 B           0 B          5204            --  
(EngineCore_DP0 pid=4220)                                         aten::flatten         0.01%       2.603ms         0.01%       3.182ms       0.213us           0 B           0 B         14904            --  
(EngineCore_DP0 pid=4220)                                            aten::view         0.06%      26.224ms         0.06%      26.224ms       0.299us           0 B           0 B         87608            --  
(EngineCore_DP0 pid=4220)                                      aten::lift_fresh         0.00%     149.694us         0.00%     149.694us       0.292us           0 B           0 B           512            --  
(EngineCore_DP0 pid=4220)                                    aten::index_select         0.00%     976.593us         0.00%     976.593us       1.907us           0 B           0 B           512            --  
(EngineCore_DP0 pid=4220)                                              [memory]         0.00%       0.000us         0.00%       0.000us       0.000us    -631.96 MB    -631.96 MB         31863            --  
(EngineCore_DP0 pid=4220)                                             aten::sub         0.01%       2.321ms         0.01%       3.967ms       7.749us       2.26 KB         552 B           512            --  
(EngineCore_DP0 pid=4220)                                              aten::to         0.00%       2.120ms         0.08%      37.647ms      10.504us     296.76 MB           0 B          3584            --  
(EngineCore_DP0 pid=4220)                                        aten::_to_copy         0.01%       4.168ms         0.08%      35.527ms      17.347us     296.76 MB       2.32 MB          2048            --  
(EngineCore_DP0 pid=4220)                                   aten::empty_strided         0.04%      18.100ms         0.04%      18.100ms       1.103us     604.02 MB     604.02 MB         16412            --  
(EngineCore_DP0 pid=4220)                                           aten::fill_         0.00%       1.420ms         0.00%       1.420ms       2.774us           0 B           0 B           512            --  
(EngineCore_DP0 pid=4220)                                          aten::detach         0.00%     826.654us         0.00%     826.654us       1.615us           0 B           0 B           512            --  
(EngineCore_DP0 pid=4220)                                    aten::resolve_conj         0.01%       4.176ms         0.01%       4.176ms       0.036us           0 B           0 B        117248            --  
(EngineCore_DP0 pid=4220)                                     aten::resolve_neg         0.00%     104.584us         0.00%     104.584us       0.068us           0 B           0 B          1536            --  
(EngineCore_DP0 pid=4220)                                          aten::select         0.08%      35.864ms         0.09%      42.561ms       1.433us           0 B           0 B         29696            --  
(EngineCore_DP0 pid=4220)                                            aten::item         0.00%       1.036ms         0.00%       1.322ms       1.291us           0 B           0 B          1024            --  
(EngineCore_DP0 pid=4220)                             aten::_local_scalar_dense         0.00%     285.604us         0.00%     285.604us       0.279us           0 B           0 B          1024            --  
(EngineCore_DP0 pid=4220)                                     Pregraph bytecode         0.09%      42.249ms         0.09%      42.249ms      82.518us           0 B           0 B           512            --  
(EngineCore_DP0 pid=4220)                AOTDispatcher Runtime Wrapper Prologue         0.01%       3.074ms         0.01%       3.074ms       6.003us           0 B           0 B           512            --  
(EngineCore_DP0 pid=4220)                                              aten::mm        26.72%       12.114s        26.73%       12.118s     209.446us     148.38 MB     148.38 MB         57856         1.656  
(EngineCore_DP0 pid=4220)                               vllm::unified_attention         1.65%     750.053ms        72.81%       33.009s       2.302ms     185.83 MB    -388.56 MB         14336            --  
(EngineCore_DP0 pid=4220)                       _C_cache_ops::reshape_and_cache         0.16%      74.798ms         0.16%      74.798ms       5.218us           0 B           0 B         14336            --  
(EngineCore_DP0 pid=4220)                                      aten::empty_like         0.02%       9.724ms         0.05%      24.819ms       1.721us     574.39 MB       4.93 MB         14420            --  
(EngineCore_DP0 pid=4220)                               aten::repeat_interleave         0.00%     366.236us         0.02%      10.699ms     191.051us     259.88 MB           0 B            56            --  
(EngineCore_DP0 pid=4220)                                       aten::unsqueeze         0.00%     847.604us         0.00%       1.006ms       1.543us           0 B           0 B           652            --  
(EngineCore_DP0 pid=4220)                                          aten::expand         0.00%      73.499us         0.00%      91.043us       1.626us           0 B           0 B            56            --  
(EngineCore_DP0 pid=4220)                                           aten::clone         0.00%     131.743us         0.02%       9.855ms     175.976us     259.88 MB           0 B            56            --  
(EngineCore_DP0 pid=4220)                                           aten::empty         0.00%     287.410us         0.00%     287.410us       2.053us     388.80 MB     388.80 MB           140            --  
(EngineCore_DP0 pid=4220)                                         aten::movedim         0.00%     253.617us         0.00%     427.986us       3.821us           0 B           0 B           112            --  
(EngineCore_DP0 pid=4220)                                         aten::permute         0.00%     132.913us         0.00%     174.369us       1.557us           0 B           0 B           112            --  
(EngineCore_DP0 pid=4220)                    aten::scaled_dot_product_attention         0.00%     185.537us        39.45%       17.884s     638.728ms     129.94 MB      -2.03 MB            28            --  
(EngineCore_DP0 pid=4220)     aten::_scaled_dot_product_flash_attention_for_cpu        39.45%       17.884s        39.45%       17.884s     638.721ms     131.97 MB    -126.90 MB            28            --  
(EngineCore_DP0 pid=4220)                                       aten::transpose         0.00%       1.080ms         0.00%       1.326ms       1.949us           0 B           0 B           680            --  
(EngineCore_DP0 pid=4220)                                         aten::squeeze         0.00%      64.789us         0.00%      70.581us       2.521us           0 B           0 B            28            --  
(EngineCore_DP0 pid=4220)                                           aten::index         0.01%       5.695ms         0.03%      11.983ms      23.405us       1.00 MB    1020.78 KB           512            --  
(EngineCore_DP0 pid=4220)                                         aten::reshape         0.00%     551.385us         0.00%     701.725us       1.371us           0 B           0 B           512            --  
(EngineCore_DP0 pid=4220)                                          aten::linear         0.00%       1.861ms         3.19%        1.445s       2.822ms     148.38 MB           0 B           512            --  
(EngineCore_DP0 pid=4220)                                               aten::t         0.00%     922.431us         0.00%       1.901ms       3.713us           0 B           0 B           512            --  
(EngineCore_DP0 pid=4220)                                          aten::matmul         0.00%       1.347ms         3.18%        1.441s       2.815ms     148.38 MB           0 B           512            --  
(EngineCore_DP0 pid=4220)                                           aten::alias         0.00%     769.825us         0.00%     769.825us       1.504us           0 B           0 B           512            --  
(EngineCore_DP0 pid=4220)                                          aten::argmax         0.20%      89.341ms         0.20%      89.606ms     175.011us       4.00 KB       4.00 KB           512            --  
(EngineCore_DP0 pid=4220)                                _C::paged_attention_v1        31.19%       14.142s        31.19%       14.142s     988.423us           0 B           0 B         14308            --  
(EngineCore_DP0 pid=4220) -----------------------------------------------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  
(EngineCore_DP0 pid=4220) Self CPU time total: 45.337s
(EngineCore_DP0 pid=4220) 
(EngineCore_DP0 pid=4220) DEBUG 09-11 19:01:11 [v1/engine/core.py:747] EngineCore waiting for work.
(EngineCore_DP0 pid=4220) DEBUG 09-11 19:01:11 [v1/engine/core.py:714] EngineCore exiting.
```
</details>

<details>
<summary>profile (pr) (CPU time total: 32.625s)</summary>
<img width="2558" height="1421" alt="image" src="https://github.com/user-attachments/assets/54a5838e-4505-4cc7-9543-1458daad44dd" />
--- output ---

Discuss the impact of the movement on society, including the civil rights movement and the civil rights movement in the United States and other countries. Conclude with the significance of the movement in the broader context of social change and equality for all people.
Answer:

**Summary of the Industrial Revolution**

The Industrial Revolution, which began in Britain in the late 18th century, marked a transformative period in human history. Technologically, it introduced machines, factories, and mass production, significantly increasing productivity and efficiency. Economically, it led to urbanization, the rise of the working class, and the growth of industries such as textiles, steel, and coal. Socially, it reshaped family structures, gender roles, and labor conditions, often leading to exploitation and poor working conditions.

The Industrial Revolution began in Britain due to several factors: the demand for labor in factories, the availability of natural resources, and the need to address growing urbanization. Over the following century, it spread globally, influencing economies, societies, and cultures in unprecedented ways. While the benefits included increased productivity and economic growth, the costs included labor exploitation, environmental damage, and social inequality.

**The Theory of Evolution by Natural Selection**

The theory of evolution by natural selection is a scientific explanation for the development of life on Earth. It posits that organisms adapt to their environment through genetic variation and natural selection, where individuals with traits that enhance survival and reproduction are more likely to pass on their genes to future generations. Darwin arrived at this theory through his observations of natural phenomena, including the fossil record and the development of species over time. Examples of adaptation in animals and plants include the development of wings in birds and the evolution of antibiotic resistance in bacteria.

The theory of evolution by natural selection has had a profound impact on biology, influencing how we understand life and its diversity. It also reshaped religion and society, as it challenged the idea of a predetermined future and emphasized the importance of natural processes.

**Examples of Natural Selection in Action**

Two classic examples of natural selection in action are the development of the peppered moth and the evolution of the human eye. The peppered moth's coloration changes in response to pollution, giving it a survival advantage. The human eye's ability to adapt to different light conditions, such as in low-light environments, is an example of natural selection.

**Healthy Weekly Meal Plan**

To create a healthy weekly meal plan, start with a balanced diet that includes proteins, carbohydrates, and healthy fats. Strategies for grocery shopping on a budget include shopping at local markets and

```
(EngineCore_DP0 pid=4296) -----------------------------------------------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  
(EngineCore_DP0 pid=4296)                                                  Name    Self CPU %      Self CPU   CPU total %     CPU total  CPU time avg       CPU Mem  Self CPU Mem    # of Calls  Total TFLOPs  
(EngineCore_DP0 pid=4296) -----------------------------------------------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  
(EngineCore_DP0 pid=4296)                                           aten::slice         0.15%      49.205ms         0.19%      62.884ms       0.629us           0 B           0 B         99902            --  
(EngineCore_DP0 pid=4296)                                      aten::as_strided         0.06%      21.155ms         0.06%      21.155ms       0.160us           0 B           0 B        132150            --  
(EngineCore_DP0 pid=4296)                                           aten::copy_         0.11%      35.778ms         0.11%      35.778ms       6.875us           0 B           0 B          5204            --  
(EngineCore_DP0 pid=4296)                                         aten::flatten         0.01%       2.503ms         0.01%       3.012ms       0.202us           0 B           0 B         14904            --  
(EngineCore_DP0 pid=4296)                                            aten::view         0.08%      25.395ms         0.08%      25.395ms       0.290us           0 B           0 B         87608            --  
(EngineCore_DP0 pid=4296)                                      aten::lift_fresh         0.00%     166.791us         0.00%     166.791us       0.326us           0 B           0 B           512            --  
(EngineCore_DP0 pid=4296)                                    aten::index_select         0.00%     970.338us         0.00%     970.338us       1.895us           0 B           0 B           512            --  
(EngineCore_DP0 pid=4296)                                              [memory]         0.00%       0.000us         0.00%       0.000us       0.000us    -631.96 MB    -631.96 MB         31926            --  
(EngineCore_DP0 pid=4296)                                             aten::sub         0.01%       2.313ms         0.01%       3.943ms       7.702us       2.48 KB         976 B           512            --  
(EngineCore_DP0 pid=4296)                                              aten::to         0.01%       2.153ms         0.11%      37.242ms      10.391us     296.76 MB           0 B          3584            --  
(EngineCore_DP0 pid=4296)                                        aten::_to_copy         0.01%       4.096ms         0.11%      35.089ms      17.133us     296.76 MB       3.48 MB          2048            --  
(EngineCore_DP0 pid=4296)                                   aten::empty_strided         0.06%      18.917ms         0.06%      18.917ms       1.153us     602.67 MB     602.67 MB         16412            --  
(EngineCore_DP0 pid=4296)                                           aten::fill_         0.00%       1.386ms         0.00%       1.386ms       2.707us           0 B           0 B           512            --  
(EngineCore_DP0 pid=4296)                                          aten::detach         0.00%     791.943us         0.00%     791.943us       1.547us           0 B           0 B           512            --  
(EngineCore_DP0 pid=4296)                                    aten::resolve_conj         0.01%       4.014ms         0.01%       4.014ms       0.034us           0 B           0 B        117248            --  
(EngineCore_DP0 pid=4296)                                     aten::resolve_neg         0.00%     105.209us         0.00%     105.209us       0.068us           0 B           0 B          1536            --  
(EngineCore_DP0 pid=4296)                                          aten::select         0.10%      32.864ms         0.12%      39.405ms       1.327us           0 B           0 B         29696            --  
(EngineCore_DP0 pid=4296)                                            aten::item         0.00%       1.014ms         0.00%       1.306ms       1.275us           0 B           0 B          1024            --  
(EngineCore_DP0 pid=4296)                             aten::_local_scalar_dense         0.00%     291.605us         0.00%     291.605us       0.285us           0 B           0 B          1024            --  
(EngineCore_DP0 pid=4296)                                     Pregraph bytecode         0.13%      42.815ms         0.13%      42.815ms      83.622us           0 B           0 B           512            --  
(EngineCore_DP0 pid=4296)                AOTDispatcher Runtime Wrapper Prologue         0.01%       2.921ms         0.01%       2.921ms       5.705us           0 B           0 B           512            --  
(EngineCore_DP0 pid=4296)                                              aten::mm        36.41%       11.877s        36.42%       11.881s     205.358us     148.38 MB     148.38 MB         57856         1.656  
(EngineCore_DP0 pid=4296)                               vllm::unified_attention         2.23%     728.007ms        62.94%       20.534s       1.432ms     185.83 MB    -388.24 MB         14336            --  
(EngineCore_DP0 pid=4296)                       _C_cache_ops::reshape_and_cache         0.21%      69.106ms         0.21%      69.106ms       4.820us           0 B           0 B         14336            --  
(EngineCore_DP0 pid=4296)                                      aten::empty_like         0.03%       9.822ms         0.08%      25.489ms       1.768us     574.07 MB       4.80 MB         14420            --  
(EngineCore_DP0 pid=4296)                                         aten::movedim         0.00%     208.627us         0.00%     361.955us       3.232us           0 B           0 B           112            --  
(EngineCore_DP0 pid=4296)                                         aten::permute         0.00%     127.704us         0.00%     153.328us       1.369us           0 B           0 B           112            --  
(EngineCore_DP0 pid=4296)                               aten::repeat_interleave         0.00%     268.283us         0.02%       5.818ms     103.889us     259.88 MB           0 B            56            --  
(EngineCore_DP0 pid=4296)                                       aten::unsqueeze         0.00%     809.676us         0.00%     970.166us       1.488us           0 B           0 B           652            --  
(EngineCore_DP0 pid=4296)                                          aten::expand         0.00%      48.251us         0.00%      60.543us       1.081us           0 B           0 B            56            --  
(EngineCore_DP0 pid=4296)                                           aten::clone         0.00%      96.786us         0.02%       5.204ms      92.932us     259.88 MB           0 B            56            --  
(EngineCore_DP0 pid=4296)                                           aten::empty         0.00%     245.871us         0.00%     245.871us       1.756us     394.80 MB     394.80 MB           140            --  
(EngineCore_DP0 pid=4296)                    aten::scaled_dot_product_attention         0.00%     170.581us        16.95%        5.530s     197.489ms     129.94 MB      -2.03 MB            28            --  
(EngineCore_DP0 pid=4296)     aten::_scaled_dot_product_flash_attention_for_cpu        16.95%        5.529s        16.95%        5.530s     197.483ms     131.97 MB    -132.90 MB            28            --  
(EngineCore_DP0 pid=4296)                                       aten::transpose         0.00%     911.591us         0.00%       1.161ms       1.708us           0 B           0 B           680            --  
(EngineCore_DP0 pid=4296)                                         aten::squeeze         0.00%      56.869us         0.00%      62.079us       2.217us           0 B           0 B            28            --  
(EngineCore_DP0 pid=4296)                                           aten::index         0.02%       5.275ms         0.03%      11.301ms      22.073us       1.00 MB    1020.94 KB           512            --  
(EngineCore_DP0 pid=4296)                                         aten::reshape         0.00%     509.574us         0.00%     643.937us       1.258us           0 B           0 B           512            --  
(EngineCore_DP0 pid=4296)                                          aten::linear         0.01%       1.749ms         4.42%        1.442s       2.816ms     148.38 MB           0 B           512            --  
(EngineCore_DP0 pid=4296)                                               aten::t         0.00%     879.586us         0.01%       1.728ms       3.375us           0 B           0 B           512            --  
(EngineCore_DP0 pid=4296)                                          aten::matmul         0.00%       1.296ms         4.41%        1.438s       2.809ms     148.38 MB           0 B           512            --  
(EngineCore_DP0 pid=4296)                                           aten::alias         0.00%     789.232us         0.00%     789.232us       1.541us           0 B           0 B           512            --  
(EngineCore_DP0 pid=4296)                                          aten::argmax         0.27%      88.990ms         0.27%      89.247ms     174.311us       4.00 KB       4.00 KB           512            --  
(EngineCore_DP0 pid=4296)                                _C::paged_attention_v1        43.10%       14.060s        43.10%       14.060s     982.668us           0 B           0 B         14308            --  
(EngineCore_DP0 pid=4296) -----------------------------------------------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  
(EngineCore_DP0 pid=4296) Self CPU time total: 32.625s
(EngineCore_DP0 pid=4296) 
(EngineCore_DP0 pid=4296) DEBUG 09-11 19:03:53 [v1/engine/core.py:747] EngineCore waiting for work.
(EngineCore_DP0 pid=4296) DEBUG 09-11 19:03:53 [v1/engine/core.py:714] EngineCore exiting.
```
</details> 
